### PR TITLE
potential fixes for filter merging and instance variable instantiation

### DIFF
--- a/lib/draco/scenes.rb
+++ b/lib/draco/scenes.rb
@@ -78,7 +78,11 @@ module Draco
         raise Draco::Scenes::MultipleSceneDefinitionsError if maybe_class && block
 
         @default_scene ||= name
-        @scene_definitions[name] = maybe_class || Class.new(Draco::World, &block)
+        @scene_definitions[name] = maybe_class || begin
+          Class.new(Draco::World).tap do |new_class|
+            new_class.class_eval(&block)
+          end
+        end
       end
 
       def default_scene(name)

--- a/lib/draco/scenes.rb
+++ b/lib/draco/scenes.rb
@@ -43,7 +43,7 @@ module Draco
       end
 
       def filter(*components)
-        super.merge(@current_scene.filter(*components))
+        Array(super) + Array(@current_scene.filter(*components))
       end
 
       def scenes


### PR DESCRIPTION
I'll start off by saying both of these commits were implemented as band-aid solutions to get scenes working in a game I'm tinkering on, and I think there are probably more elegant solutions to be found so I'm opening this PR to start a conversation.

## Issue 1
```ruby
def filter(*components)
  super.merge(@current_scene.filter(*components))
end
```
I was running into a `NoMethodError` in that function where `super` would return either `nil` or an `array`, neither of which were capable of responding to `merge`. Changing this method to combine arrays was a workable band-aid.

```ruby
def filter(*components)
  Array(super) + Array(@current_scene.filter(*components))
end
```

## Issue 2
```ruby
@scene_definitions[name] = maybe_class || Class.new(Draco::World, &block)
```
For some reason when using the block format of instantiating `World` instances the default instance variables were not being instantiated which was causing downstream errors when we would attempt to shovel records onto either of those arrays.
```ruby
@scene_definitions[name] = maybe_class || begin
  Class.new(Draco::World).tap do |new_class|
    new_class.class_eval(&block)
  end
end
```